### PR TITLE
Allow to configure root domain in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  
+  if ENV['ROOT_DOMAIN']
+    config.session_store :cookie_store,
+                         key: '_barong_session',
+                         domain: ".#{ENV.fetch('ROOT_DOMAIN')}"
+  end
 end


### PR DESCRIPTION
Workbench works in development mode