### PR TITLE
Add a stronger validation for passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'fontello_rails_converter'
 gem 'bootstrap-datepicker-rails'
 gem 'public_suffix'
 gem 'devise-security'
+gem 'devise-pwned_password'
 gem 'email_validator', require: 'email_validator/strict'
 
 gem 'doorkeeper-jwt', git: 'https://github.com/rubykube/doorkeeper-jwt.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,9 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    devise-pwned_password (0.1.6)
+      devise (~> 4)
+      pwned (~> 1.2.1)
     devise-security (0.12.0)
       devise (>= 4.2.0, < 5.0)
       rails (>= 4.1.0, < 6.0)
@@ -264,6 +267,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.3)
     puma (3.12.0)
+    pwned (1.2.1)
     rack (2.0.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -425,6 +429,7 @@ DEPENDENCIES
   chromedriver-helper (~> 1.1)
   countries
   devise (~> 4.4)
+  devise-pwned_password
   devise-security
   discard (~> 1.0)
   doorkeeper (~> 4.4.2)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -8,7 +8,7 @@ class Account < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :secure_validatable,
+         :recoverable, :rememberable, :trackable, :secure_validatable, :pwned_password,
          :confirmable, :lockable
 
   ROLES = %w[admin compliance member].freeze

--- a/lib/tasks/db_load_fake.rake
+++ b/lib/tasks/db_load_fake.rake
@@ -4,10 +4,10 @@ namespace :db do
   namespace :load do
     desc 'Creating the fake data'
     task fake: :environment do
-      account = Account.create!(email: 'admin@gmail.com', password: 'Pass123123', role: 'admin', confirmed_at: Faker::Time.between(2.days.ago, Date.today))
+      account = Account.create!(email: 'admin@gmail.com', password: 'Haepood8', role: 'admin', confirmed_at: Faker::Time.between(2.days.ago, Date.today))
       Profile.create!(account: account, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, country: Faker::Address.country, dob: Faker::Date.between(25.years.ago, 10.years.ago), address: Faker::Address.street_address, city: Faker::Address.city)
 
-      compliance = Account.create!(email: 'compliance@gmail.com', password: 'Pass123123', role: 'compliance', confirmed_at: Faker::Time.between(2.days.ago, Date.today))
+      compliance = Account.create!(email: 'compliance@gmail.com', password: 'Haepood8', role: 'compliance', confirmed_at: Faker::Time.between(2.days.ago, Date.today))
       Profile.create!(account: compliance, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, country: Faker::Address.country, dob: Faker::Date.between(25.years.ago, 10.years.ago), address: Faker::Address.street_address, city: Faker::Address.city)
 
       [*1..100].each do

--- a/spec/api/management_api_v1/accounts_spec.rb
+++ b/spec/api/management_api_v1/accounts_spec.rb
@@ -72,7 +72,7 @@ describe ManagementAPI::V1::Accounts, type: :request do
         let(:params) do
           {
             email: 'valid_email@example.com',
-            password: 'Password1'
+            password: 'Fai5aeso'
           }
         end
         let!(:application) { create :doorkeeper_application }
@@ -99,7 +99,7 @@ describe ManagementAPI::V1::Accounts, type: :request do
         it 'renders an error' do
           expect { do_request }.to_not change { Account.count }
           expect_status_to_eq 422
-          expect_body.to eq(error: ['Email is invalid'])
+          expect_body.to eq(error: ['Email is invalid', 'Password has previously appeared in a data breach and should never be used. Please choose something harder to guess.'])
         end
       end
 

--- a/spec/api/user_api/v1/accounts_spec.rb
+++ b/spec/api/user_api/v1/accounts_spec.rb
@@ -36,7 +36,7 @@ describe 'Api::V1::Accounts' do
       it 'renders an error' do
         do_request
         expect_status_to_eq 422
-        expect_body.to eq(error: ['Email is invalid'])
+        expect_body.to eq(error: ['Email is invalid', 'Password has previously appeared in a data breach and should never be used. Please choose something harder to guess.'])
       end
     end
 
@@ -46,7 +46,7 @@ describe 'Api::V1::Accounts' do
       it 'renders an error' do
         do_request
         expect_status_to_eq 422
-        expect_body.to eq(error: ['Password does not meet the minimum system requirements. It should be composed of uppercase and lowercase letters, and numbers.'])
+        expect_body.to eq(error: ['Password does not meet the minimum system requirements. It should be composed of uppercase and lowercase letters, and numbers.', 'Password has previously appeared in a data breach and should never be used. Please choose something harder to guess.'])
       end
     end
 
@@ -61,7 +61,7 @@ describe 'Api::V1::Accounts' do
     end
 
     context 'when email is blank' do
-      let(:params) { { email: '', password: 'Password1' } }
+      let(:params) { { email: '', password: 'zieV0Kai' } }
 
       it 'renders an error' do
         do_request
@@ -71,7 +71,7 @@ describe 'Api::V1::Accounts' do
     end
 
     context 'when email is valid' do
-      let(:params) { { email: 'vadid.email@gmail.com', password: 'Password1' } }
+      let(:params) { { email: 'vadid.email@gmail.com', password: 'eeC2BiCu' } }
 
       it 'creates an account' do
         do_request
@@ -84,7 +84,7 @@ describe 'Api::V1::Accounts' do
       after { ENV['CAPTCHA_ENABLED'] = nil }
 
       context 'when captcha response is blank' do
-        let(:params) { { email: 'vadid.email@gmail.com', password: 'Password1' } }
+        let(:params) { { email: 'vadid.email@gmail.com', password: 'quooR4ew' } }
 
         it 'renders an error' do
           do_request
@@ -97,7 +97,7 @@ describe 'Api::V1::Accounts' do
         let(:params) do
           {
             email: 'vadid.email@gmail.com',
-            password: 'Password1',
+            password: 'eFo8aesi',
             recaptcha_response: 'invalid'
           }
         end
@@ -117,7 +117,7 @@ describe 'Api::V1::Accounts' do
         let(:params) do
           {
             email: 'vadid.email@gmail.com',
-            password: 'Password1',
+            password: 'Deivoh3a',
             recaptcha_response: 'invalid'
           }
         end
@@ -136,26 +136,26 @@ describe 'Api::V1::Accounts' do
 
   describe 'PUT /api/v1/accounts/password' do
     let(:url) { '/api/v1/accounts/password' }
-    let!(:password0) { 'Testpassword111' }
-    let!(:password1) { 'Testpassword123' }
+    let!(:password0) { 'Aeth7sha' }
+    let!(:password1) { 'Iene0eej' }
     let(:params0) do
       {
-        old_password: 'Password0',
-        new_password: 'Password1'
+        old_password: 'faezu6Te',
+        new_password: 'Aijae7gu'
       }
     end
 
     let(:params1) do
       {
-        old_password: 'Password1',
-        new_password: 'Password0'
+        old_password: 'Aijae7gu',
+        new_password: 'quee2ooV'
       }
     end
 
     subject!(:acc) do
       create :account,
-             password: 'Password0',
-             password_confirmation: 'Password0'
+             password: 'faezu6Te',
+             password_confirmation: 'faezu6Te'
     end
 
     let!(:access_token) do

--- a/spec/api/user_api/v1/security_spec.rb
+++ b/spec/api/user_api/v1/security_spec.rb
@@ -236,7 +236,7 @@ describe 'Api::V1::Security' do
 
     context 'when Reset Password Token is invalid' do
       let(:reset_password_token) { 'invalid' }
-      let(:password) { 'Password1' }
+      let(:password) { 'Gol4aid2' }
 
       it 'renders 404 error' do
         do_request
@@ -248,7 +248,7 @@ describe 'Api::V1::Security' do
     context 'when Reset Password Token is valid' do
       let!(:account) { create(:account) }
       let(:reset_password_token) { account.send_reset_password_instructions }
-      let(:password) { 'Password1' }
+      let(:password) { 'ZahSh8ei' }
 
       it 'resets a password' do
         expect { do_request }.to change { account.reload.encrypted_password }

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     doc_expire { Faker::Business.credit_card_expiry_date }
 
     after(:build) do |doc|
-      doc.upload.download!(Faker::Avatar.image)
+      doc.upload.download!(Faker::Company.logo)
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Account, type: :model do
 
   context 'Account with 2 or more documents' do
     it do
-      account = Account.create!(email: 'test@gmail.com', password: 'Pass123123')
+      account = Account.create!(email: 'test@gmail.com', password: 'ZahSh8ei')
       expect(Account.count).to eq 1
       document1 = account.documents.create!(upload: uploaded_file,
                                             doc_type: 'Passport',


### PR DESCRIPTION
Use devise-pwned-password gem to avoid accepting weak passwords that has been already cracked.
This is not an ultimate solution, but could be a part of it. This will not work if haveibeenpwned service fails
