### PR TITLE
Fix account unlocking (account should be unlocked after 1 hour by default)

### DIFF
--- a/app/api/user_api/v1/sessions.rb
+++ b/app/api/user_api/v1/sessions.rb
@@ -50,7 +50,7 @@ module UserApi
 
           application = Doorkeeper::Application.find_by(uid: declared_params[:application_id])
           error!('Wrong Application ID', 401) unless application
-          error!('Your account was locked!', 401) unless account.locked_at.nil?
+          error!('Your account was locked!', 401) if account.access_locked?
 
           unless account.valid_password? declared_params[:password]
             handle_session_captcha(account: account,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -195,7 +195,7 @@ Devise.setup do |config|
   config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  config.unlock_in = 1.hour
+  config.unlock_in = ENV.fetch('UNLOCK_IN', '60').to_i.minutes
 
   # Warn on the last attempt before the account is locked.
   config.last_attempt_warning = false


### PR DESCRIPTION
+ Account unlocks after 1 hour by default
+ Add ability to configure unlock time with `"UNLOCK_IN"` env variable.