### PR TITLE
Expose Referral UID in API

### DIFF
--- a/app/api/v2/entities/user.rb
+++ b/app/api/v2/entities/user.rb
@@ -8,7 +8,7 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
-        expose :referral_id, documentation: { type: 'String' }
+        expose :referral_uid, documentation: { type: 'String' }
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user.rb
+++ b/app/api/v2/entities/user.rb
@@ -8,6 +8,7 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
+        expose :referral_id, documentation: { type: 'String' }
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user.rb
+++ b/app/api/v2/entities/user.rb
@@ -8,7 +8,9 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
-        expose :referral_uid, documentation: { type: 'String' }
+        expose :referral_uid do |item,options|
+          item.referral_uid
+        end
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_full_info.rb
+++ b/app/api/v2/entities/user_with_full_info.rb
@@ -8,7 +8,7 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
-        expose :referral_id, documentation: { type: 'String' }
+        expose :referral_uid, documentation: { type: 'String' }
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_full_info.rb
+++ b/app/api/v2/entities/user_with_full_info.rb
@@ -8,6 +8,7 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
+        expose :referral_id, documentation: { type: 'String' }
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_full_info.rb
+++ b/app/api/v2/entities/user_with_full_info.rb
@@ -8,7 +8,9 @@ module API
         format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
         expose :email, documentation: { type: 'String' }
-        expose :referral_uid, documentation: { type: 'String' }
+        expose :referral_uid do |item,options|
+          item.referral_uid
+        end
         expose :uid, documentation: { type: 'String' }
         expose :role, documentation: { type: 'String' }
         expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_profile.rb
+++ b/app/api/v2/entities/user_with_profile.rb
@@ -6,6 +6,7 @@ module API::V2
       format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
       expose :email, documentation: { type: 'String' }
+      expose :referral_id, documentation: { type: 'String' }
       expose :uid, documentation: { type: 'String' }
       expose :role, documentation: { type: 'String' }
       expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_profile.rb
+++ b/app/api/v2/entities/user_with_profile.rb
@@ -6,7 +6,7 @@ module API::V2
       format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
       expose :email, documentation: { type: 'String' }
-      expose :referral_id, documentation: { type: 'String' }
+      expose :referral_uid, documentation: { type: 'String' }
       expose :uid, documentation: { type: 'String' }
       expose :role, documentation: { type: 'String' }
       expose :level, documentation: { type: 'Integer' }

--- a/app/api/v2/entities/user_with_profile.rb
+++ b/app/api/v2/entities/user_with_profile.rb
@@ -6,7 +6,9 @@ module API::V2
       format_with(:iso_timestamp) { |d| d&.utc&.iso8601 }
 
       expose :email, documentation: { type: 'String' }
-      expose :referral_uid, documentation: { type: 'String' }
+      expose :referral_uid do |item,options|
+        item.referral_uid
+      end
       expose :uid, documentation: { type: 'String' }
       expose :role, documentation: { type: 'String' }
       expose :level, documentation: { type: 'Integer' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,8 @@ class User < ApplicationRecord
   end
 
   def referral_uid
-    Member.where(uid: referral_id).first
+    member = Member.where(uid: referral_id).first
+    return member.uid if member
   end
 
   def add_level_label(key, value = 'verified')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
   end
 
   def referral_uid
-    member = Member.where(uid: referral_id).first
+    member = User.where(uid: referral_id).first
     return member.uid if member
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
   end
 
   def referral_uid
-    member = User.where(uid: referral_id).first
+    member = User.find(referral_id)
     return member.uid if member
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,7 @@ class User < ApplicationRecord
     {
       uid: uid,
       email: email,
+      referral_id: referral_id,
       role: role,
       level: level,
       otp: otp,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ApplicationRecord
     update(level: user_level)
   end
 
+  def referral_uid
+    Member.where(uid: referral_id).first
+  end
+
   def add_level_label(key, value = 'verified')
     labels.find_or_create_by(key: key, scope: 'private')
           .update!(value: value)
@@ -70,7 +74,7 @@ class User < ApplicationRecord
     {
       uid: uid,
       email: email,
-      referral_id: referral_id,
+      referral_uid: referral_uid,
       role: role,
       level: level,
       otp: otp,


### PR DESCRIPTION
This should close #802 
Using UID instead of ID because the ID will be different in different systems i.e peatio.