### PR TITLE
Changes in admin API module

### DIFF
--- a/app/api/v2/admin/activities.rb
+++ b/app/api/v2/admin/activities.rb
@@ -41,7 +41,7 @@ module API
                      desc: 'Number of users per page (defaults to 100, maximum is 100).'
           end
           get do
-            activities = API::V2::Queries::ActivityFilter.new(Activity.all).call(permitted_search_params(params))
+            activities = API::V2::Queries::ActivityFilter.new(Activity.where(category: 'user')).call(permitted_search_params(params))
             activities.tap { |q| present paginate(q), with: API::V2::Entities::ActivityWithUser }
           end
 

--- a/app/api/v2/admin/permissions.rb
+++ b/app/api/v2/admin/permissions.rb
@@ -135,7 +135,9 @@ module API
               error!({ errors: ["admin.permission.#{update_param_key}_no_change"] }, 422)
             end
 
-            target_permission.update(update_param_key => update_param_value)
+            unless target_permission.update(update_param_key => update_param_value)
+              code_error!(target_permission.errors.details, 422)
+            end
             # clear cached permissions, so they will be freshly refetched on the next call to /auth
             Rails.cache.write('permissions', nil)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -85,7 +85,7 @@ admin.user.empty_uid
 admin.user.empty_state
 admin.user.empty_otp
 admin.user.empty_role
-admin.user.one_of_role_state_otp
+admin.user.one_of_state_otp
 admin.user.missing_key
 admin.user.empty_key
 admin.user.missing_scope

--- a/spec/api/v2/admin/activities_spec.rb
+++ b/spec/api/v2/admin/activities_spec.rb
@@ -22,13 +22,24 @@ describe API::V2::Admin::Activities do
       let!(:second_user) { create(:user, email: 'test2@gmail.com') }
 
       context 'user activities' do
-        let!(:first_activity) { create(:activity, topic: 'session', action: 'login', user: first_user) }
-        let!(:second_activity) { create(:activity, topic: 'session', action: 'login', user: second_user) }
-        let!(:third_activity) { create(:activity, topic: 'otp', action: 'otp::enable', user: second_user) }
+        let!(:create_actitivites) do
+          create(:activity, category: 'user', topic: 'session', action: 'login', user: first_user)
+          create(:activity, category: 'user', topic: 'session', action: 'login', user: second_user)
+          create(:activity, category: 'user', topic: 'otp', action: 'otp::enable', user: second_user)
+          create(:activity, category: 'admin', topic: 'otp', action: 'otp::enable', user: second_user)
+        end
+
+        it 'doesnt return admin activities' do
+          get '/api/v2/admin/activities', headers: auth_header
+          activities = JSON.parse(response.body)
+          expect(Activity.where(category: 'user').count).to eq activities.count
+          expect(Activity.all.count).not_to eq activities.count
+        end
+
         it 'returns list of activities' do
           get '/api/v2/admin/activities', headers: auth_header
           activities = JSON.parse(response.body)
-          expect(Activity.count).to eq activities.count
+          expect(Activity.where(category: 'user').count).to eq activities.count
           expect(Activity.first.user_ip).to eq activities[0]['user_ip']
           expect(Activity.first.user_agent).to eq activities[0]['user_agent']
           expect(Activity.first.topic).to eq activities[0]['topic']
@@ -70,9 +81,12 @@ describe API::V2::Admin::Activities do
       end
 
       context 'admin activities' do
-        let!(:first_activity) { create(:activity, topic: 'session', action: 'login', user: first_user, category: 'admin', target_uid: second_user.uid) }
-        let!(:second_activity) { create(:activity, topic: 'session', action: 'login', user: second_user, category: 'admin') }
-        let!(:third_activity) { create(:activity, topic: 'otp', action: 'otp::enable', user: second_user, category: 'admin', target_uid: second_user.uid) }
+        let!(:create_actitivites) do
+          create(:activity, topic: 'session', action: 'login', user: first_user, category: 'admin', target_uid: second_user.uid)
+          create(:activity, topic: 'session', action: 'login', user: second_user, category: 'admin')
+          create(:activity, topic: 'otp', action: 'otp::enable', user: second_user, category: 'admin', target_uid: second_user.uid)
+        end
+
         it 'returns list of activities' do
           get '/api/v2/admin/activities/admin', headers: auth_header
           activities = JSON.parse(response.body)

--- a/spec/api/v2/admin/users_spec.rb
+++ b/spec/api/v2/admin/users_spec.rb
@@ -179,7 +179,7 @@ describe API::V2::Admin::Users do
           uid: experimental_user.uid
         }
         expect(response.status).to eq 422
-        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_role_state_otp\"]}"
+        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_state_otp\"]}"
       end
 
       it 'renders error if otp is misssing' do
@@ -187,7 +187,7 @@ describe API::V2::Admin::Users do
           uid: experimental_user.uid
         }
         expect(response.status).to eq 422
-        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_role_state_otp\"]}"
+        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_state_otp\"]}"
       end
 
       it 'renders error if role is misssing' do
@@ -195,7 +195,7 @@ describe API::V2::Admin::Users do
           uid: experimental_user.uid
         }
         expect(response.status).to eq 422
-        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_role_state_otp\"]}"
+        expect(response.body).to eq "{\"errors\":[\"admin.user.one_of_state_otp\"]}"
       end
 
       it 'renders error if uid is incorrect' do
@@ -227,7 +227,7 @@ describe API::V2::Admin::Users do
       end
 
       it 'sets role to admin' do
-        put '/api/v2/admin/users', headers: auth_header, params: {
+        post '/api/v2/admin/users/role', headers: auth_header, params: {
           uid: experimental_user.uid,
           role: 'admin'
         }


### PR DESCRIPTION
* Split user update endpoint into /role and /update (state, 2fa) endpoints
* Return only user activity on GET /activities and only admin on GET /activities/admin
* Return encoded(dictionary) error if permission update fails
* Return encoded(dictionary) error if user update fails
* Return encoded(dictionary) error if label update fails