### PR TITLE
Server side sessions implementation (cache store)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,15 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '~> 2.6.5'
 
+gem 'aliyun-sdk',  '~> 0.7.0'
 gem 'api-pagination', '~> 4.8.2'
 
 gem 'env-tweaks', '~> 1.0.0'
 
-gem 'fog-google',  '~> 0.1.0'
-gem 'fog-aws',     '~> 2.0.1'
 gem 'fog-aliyun',  '~> 0.3.5'
-gem 'aliyun-sdk',  '~> 0.7.0'
+gem 'fog-aws',     '~> 2.0.1'
+gem 'fog-google',  '~> 0.1.0'
+gem 'hiredis', '~> 0.6.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # Use mysql as the database for Active Record
@@ -25,7 +26,6 @@ gem 'mini_racer', platforms: :ruby
 gem 'maxmind-db', '~> 1.0'
 
 gem 'kaminari'
-
 gem 'peatio', '~> 0.4.4'
 gem 'rack-cors', '~> 1.0.2'
 
@@ -42,9 +42,8 @@ gem 'bunny'
 gem 'phonelib',     '~> 0.6.0'
 gem 'twilio-ruby',  '~> 5.25.4'
 gem 'vault',        '~> 0.1'
-gem 'redis-rails', '~> 5'
 # Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
+gem 'redis', '~> 4.0'
 
 gem 'bcrypt', '~> 3.1'
 # Email validators. Lock at 1.6.0 to use /strict dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       rack
     grape_on_rails_routes (0.3.2)
       rails (>= 3.1.1)
+    hiredis (0.6.3)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -290,22 +291,6 @@ GEM
     recaptcha (5.1.0)
       json
     redis (4.1.2)
-    redis-actionpack (5.0.2)
-      actionpack (>= 4.0, < 6)
-      redis-rack (>= 1, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.0.7)
-      activesupport (>= 3, < 6)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.0.5)
-      rack (>= 1.5, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.6.0)
-      redis (>= 2.2, < 5)
     regexp_parser (1.6.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -406,6 +391,7 @@ DEPENDENCIES
   grape-swagger-entity (~> 0.2)
   grape_logging (~> 1.8.0)
   grape_on_rails_routes (~> 0.3.2)
+  hiredis (~> 0.6.1)
   jwt (~> 2.2)
   jwt-multisig (~> 1.0)
   kaminari
@@ -423,7 +409,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   recaptcha
-  redis-rails (~> 5)
+  redis (~> 4.0)
   rspec-rails (~> 3.8)
   shoulda-matchers (~> 4.0.0.rc1)
   spring

--- a/app/api/v2/identity/sessions.rb
+++ b/app/api/v2/identity/sessions.rb
@@ -5,8 +5,6 @@ require_dependency 'barong/jwt'
 module API::V2
   module Identity
     class Sessions < Grape::API
-      use ActionDispatch::Session::CookieStore
-
       desc 'Session related routes'
       resource :sessions do
         desc 'Start a new session',
@@ -57,7 +55,7 @@ module API::V2
 
           unless user.otp
             activity_record(user: user.id, action: 'login', result: 'succeed', topic: 'session')
-            session[:uid] = user.uid
+            open_session(user)
             publish_session_create(user)
 
             present user, with: API::V2::Entities::UserWithFullInfo
@@ -75,7 +73,7 @@ module API::V2
           end
 
           activity_record(user: user.id, action: 'login::2fa', result: 'succeed', topic: 'session')
-          session[:uid] = user.uid
+          open_session(user)
           publish_session_create(user)
 
           present user, with: API::V2::Entities::UserWithFullInfo

--- a/app/controllers/authorize_controller.rb
+++ b/app/controllers/authorize_controller.rb
@@ -5,7 +5,6 @@ require_dependency 'barong/authorize'
 # Rails Metal base controller to manage AuthZ story
 class AuthorizeController < ActionController::Metal
   include AbstractController::Rendering
-  use ActionDispatch::Session::CookieStore
 
   # /api/v2/auth endpoint
   def authorize
@@ -15,8 +14,6 @@ class AuthorizeController < ActionController::Metal
 
     response.status = 200
     return if req.restricted?('pass') # check if request is whitelisted
-
-    request.session_options[:expire_after] = Barong::App.config.session_expire_time.to_i.seconds
 
     response.headers['Authorization'] = req.auth # sets bearer token
   rescue Barong::Authorize::AuthError => e # returns error from validations

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,8 +60,4 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.cache_store = :redis_store, Barong::App.config.redis_url
-  config.session_store :cookie_store,
-                       key: '_barong_session',
-                       domain: :all,
-                       tld_length: 2
 end

--- a/config/initializers/barong.rb
+++ b/config/initializers/barong.rb
@@ -42,6 +42,7 @@ Barong::App.define do |config|
   config.set(:barong_uid_prefix, 'ID', regex: /^[A-z]{2,6}$/)
   config.set(:barong_config, 'config/barong.yml', type: :path)
   config.set(:barong_maxminddb_path, '', type: :path)
+  config.set(:session_expire_time, '1800', type: :integer)
   config.set(:barong_geoip_lang, 'en', values: %w[en de es fr ja ru])
 end
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,5 +1,5 @@
 Barong::App.define do |config|
   config.set(:api_cors_origins, '*')
-  config.set(:api_cors_max_age, '3600', type: :integer)
+  config.set(:api_cors_max_age, '3600')
   config.set(:api_cors_allow_credentials, 'false', type: :bool)
 end

--- a/config/initializers/sessions_store.rb
+++ b/config/initializers/sessions_store.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal:true
 
-# Store sessions in cookies
-Rails.application.config.session_store :cookie_store, key: '_barong_session'
-Barong::App.set(:session_expire_time, '1800', type: :integer)
+# Store sessions in cache
+Rails.application.config.session_store :cache_store, key: '_barong_session', expire_after: 24.hours.seconds

--- a/lib/barong/app.rb
+++ b/lib/barong/app.rb
@@ -59,7 +59,7 @@ module Barong
           return value == 'true'
         when :integer
           regex!(key, value,  /^\d+$/)
-          return value
+          return value.to_i
         when :path
           return Rails.root.join(value).tap { |p| path!(key, p) }
         end

--- a/spec/api/v2/auth/auth_spec.rb
+++ b/spec/api/v2/auth/auth_spec.rb
@@ -20,7 +20,7 @@ describe '/api/v2/auth functionality test' do
     }
   end
 
-  let(:do_create_session_request) { post uri, params: params, headers: { 'HTTP_USER_AGENT' => 'random-browser' } }
+  let(:do_create_session_request) { post uri, params: params }
   let(:auth_request) { '/api/v2/auth/not_in_the_rules_path' }
   let(:protected_request) { '/api/v2/resource/users/me' }
 
@@ -37,18 +37,6 @@ describe '/api/v2/auth functionality test' do
         expect(response.status).to eq(200)
         expect(response.headers['Authorization']).not_to be_nil
         expect(response.headers['Authorization']).to include "Bearer"
-      end
-
-      it 'returns set-cookie header with updated expiration' do
-        expect {
-          get auth_request
-        }.to change { response.cookies }
-
-        expect(response.status).to eq(200)
-        expect(response.headers['Set-Cookie']).not_to be_nil
-        expect(
-          Time.parse(response.headers['Set-Cookie'].split(';')[-2].split('=')[1])
-        ).to be_within(10).of(Time.now + 30.minutes)
       end
 
       it 'allows any type of request' do

--- a/spec/api/v2/auth/rbac_spec.rb
+++ b/spec/api/v2/auth/rbac_spec.rb
@@ -18,7 +18,7 @@ describe '/api/v2/auth functionality test' do
     end
 
     context 'with cookies' do
-      let(:do_create_session_request_superadm) { post  '/api/v2/identity/sessions', params: { email: 'superadmin@admin.io', password: 'Tecohvi0' }, headers: { 'HTTP_USER_AGENT' => 'random-browser' } }
+      let(:do_create_session_request_superadm) { post  '/api/v2/identity/sessions', params: { email: 'superadmin@admin.io', password: 'Tecohvi0' }}
 
       context 'not enough permissions' do
         it 'denies access for user with missing cookies' do

--- a/spec/api/v2/auth/restriction_spec.rb
+++ b/spec/api/v2/auth/restriction_spec.rb
@@ -17,11 +17,12 @@ describe '/api/v2/auth functionality test' do
       password: user.password
     }
   end
-  let(:do_create_session_request) { post uri, params: params, headers: { 'HTTP_USER_AGENT' => 'random-browser' } }
+  let(:do_create_session_request) { post uri, params: params }
   let(:auth_request) { '/api/v2/auth/tasty_endpoint' }
 
   describe 'test restrictions' do
     before do
+      allow_any_instance_of(Barong::Authorize).to receive(:validate_session!).and_return(true)
       Rails.cache.delete('restrictions')
       do_create_session_request
     end

--- a/spec/api/v2/auth/sessions_spec.rb
+++ b/spec/api/v2/auth/sessions_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+include ActiveSupport::Testing::TimeHelpers
+
+describe '/api/v2/auth functionality test' do
+  include_context 'geoip mock'
+
+  let(:session_expire_time) do
+    Barong::App.config.session_expire_time.to_i.seconds
+  end
+  let!(:create_permissions) do
+    create :permission, role: 'admin'
+    create :permission, role: 'member', action: 'ACCEPT', verb: 'all', path: 'not_in_the_rules_path'
+    create :permission, role: 'member', action: 'ACCEPT', verb: 'get', path: '/api/v2/resource/users/me'
+    create :permission, role: 'accountant'
+  end
+  let!(:user) { create(:user) }
+  let(:params) do
+    {
+      email: user.email,
+      password: user.password
+    }
+  end
+
+  let(:do_destroy_session_request) { delete '/api/v2/identity/sessions', headers: { 'HTTP_USER_AGENT': 'legacy-browser' } }
+  let(:do_create_session_request) { post '/api/v2/identity/sessions', params: params, headers: { 'HTTP_USER_AGENT': 'legacy-browser' } }
+  let(:auth_request) { '/api/v2/auth/not_in_the_rules_path' }
+
+  describe 'testing session hash validations' do
+    before do
+      Rails.cache.delete('permissions')
+    end
+
+    context 'with valid ip, browser' do
+      it 'authorize traffic' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+
+        expect(response.status).to eq(200)
+        expect(response.headers['Authorization']).not_to be_nil
+        expect(response.headers['Authorization']).to include "Bearer"
+      end
+    end
+
+    context 'when session params has changed after session opening' do
+      it 'return error if USER_AGENT changes' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'new-browser' }
+        expect(response.status).to eq(401)
+        expect(response.headers['Authorization']).to be_nil
+      end
+
+      it 'return error if IP changes' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'REMOTE_ADDR': '128.0.0.12' }
+        expect(response.status).to eq(401)
+        expect(response.headers['Authorization']).to be_nil
+      end
+
+      it 'return error if everything changes' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'REMOTE_ADDR': '128.0.0.12', 'HTTP_USER_AGENT': 'new-browser' }
+        expect(response.status).to eq(401)
+        expect(response.headers['Authorization']).to be_nil
+      end
+    end
+  end
+
+  describe 'testing session renewal' do
+    before do
+      Rails.cache.delete('permissions')
+    end
+
+    context 'with valid session' do
+      it 'authorize traffic and renew session every request' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+
+        expect(response.status).to eq(200)
+        expect(response.headers['Authorization']).not_to be_nil
+        expect(response.headers['Authorization']).to include "Bearer"
+        start_time = Time.current
+
+        30.times do
+          # 5 minute before session will expire
+          travel session_expire_time - 5.minutes
+
+          # renew session with private request
+          post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+
+          expect(response.status).to eq(200)
+          expect(response.headers['Authorization']).not_to be_nil
+          expect(response.headers['Authorization']).to include "Bearer"
+        end
+
+        expect(Time.current).to be > (start_time + session_expire_time)
+
+        travel session_expire_time + 10.minutes
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe 'testing session destroy' do
+    before do
+      Rails.cache.delete('permissions')
+    end
+
+    context 'with valid session' do
+      it 'deletes session from cache on #logout' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+
+        expect(response.status).to eq(200)
+        expect(response.headers['Authorization']).not_to be_nil
+        expect(response.headers['Authorization']).to include "Bearer"
+
+        do_destroy_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with invalid session params' do
+      it 'deletes session from cache on auth if params is wrong' do
+        do_create_session_request
+        expect(response.status).to eq(200)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+
+        expect(response.status).to eq(200)
+        expect(response.headers['Authorization']).not_to be_nil
+        expect(response.headers['Authorization']).to include "Bearer"
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'new-browser' }
+        expect(response.status).to eq(401)
+
+        post auth_request, headers: { 'HTTP_USER_AGENT': 'legacy-browser' }
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end

--- a/spec/api/v2/identity/sessions_spec.rb
+++ b/spec/api/v2/identity/sessions_spec.rb
@@ -29,7 +29,7 @@ describe API::V2::Identity::Sessions do
     context 'With valid params' do
       let(:do_request) { post uri, params: params }
       let(:session_expire_time) do
-        Barong::App.config.session_expire_time.to_i.seconds
+        Barong::App.config.session_expire_time
       end
       let(:check_session) do
         get '/api/v2/auth/api/v2/tasty_endpoint'
@@ -43,17 +43,15 @@ describe API::V2::Identity::Sessions do
 
       it 'Check current credentials and returns session' do
         do_request
-        expect(session[:uid]).to eq(user.uid)
-        expect(session.options.to_hash[:expire_after]).to eq(
-          session_expire_time
-        )
+
+        expect(session.instance_variable_get(:@delegate)[:uid]).to eq(user.uid)
         expect_status.to eq(200)
 
         check_session
         expect(response.status).to eq(200)
       end
 
-       it 'Expires a session after configured time' do
+      it 'Expires a session after configured time' do
         do_request
         travel session_expire_time + 30.minutes
         check_session
@@ -241,20 +239,20 @@ describe API::V2::Identity::Sessions do
 
       it 'Deletes session' do
         do_create_session_request
-        expect(session[:uid]).to eq(user.uid)
+        expect(session.instance_variable_get(:@delegate)[:uid]).to eq(user.uid)
 
         do_delete_session_request
-        expect(session[:uid]).to eq(nil)
+        expect(session.instance_variable_get(:@delegate)[:uid]).to eq(nil)
       end
 
       it "return invalid set-cookie header on #logout" do
         do_create_session_request
-        expect(session[:uid]).to eq(user.uid)
+        expect(session.instance_variable_get(:@delegate)[:uid]).to eq(user.uid)
 
         do_delete_session_request
         expect(response.status).to eq(200)
         expect(response.headers['Set-Cookie']).not_to be_nil
-        expect(response.headers['Set-Cookie']).to include "_session_id"
+        expect(response.headers['Set-Cookie']).to include "barong_session"
       end
     end
   end

--- a/spec/api/v2/identity/users_spec.rb
+++ b/spec/api/v2/identity/users_spec.rb
@@ -291,7 +291,7 @@ describe API::V2::Identity::Users do
     let(:do_request) { post '/api/v2/identity/users', params: params }
     let(:params) { { email: email, password: 'Tecohvi0' } }
     let(:session_expire_time) do
-      Barong::App.config.session_expire_time.to_i.seconds
+      Barong::App.config.session_expire_time
     end
     let(:check_session) do
       get '/api/v2/auth/tasty_endpoint'
@@ -302,10 +302,7 @@ describe API::V2::Identity::Users do
       user = User.find_by(email: email)
 
       expect(user).not_to be(nil)
-      expect(session[:uid]).to eq(user.uid)
-      expect(session.options.to_hash[:expire_after]).to eq(
-        session_expire_time
-      )
+      expect(session.instance_variable_get(:@delegate)[:uid]).to eq(user.uid)
       expect_status.to eq(201)
 
       check_session
@@ -354,7 +351,7 @@ describe API::V2::Identity::Users do
     let(:do_request) { post '/api/v2/identity/users/email/confirm_code', params: params }
     let(:params) { { token: codec.encode(sub: 'confirmation', email: user.email, uid: user.uid) } }
     let(:session_expire_time) do
-      Barong::App.config.session_expire_time.to_i.seconds
+      Barong::App.config.session_expire_time
     end
     let(:check_session) do
       get '/api/v2/auth/tasty_endpoint'
@@ -364,10 +361,7 @@ describe API::V2::Identity::Users do
       do_request
 
       expect(user).not_to be(nil)
-      expect(session[:uid]).to eq(user.uid)
-      expect(session.options.to_hash[:expire_after]).to eq(
-        session_expire_time
-      )
+      expect(session.instance_variable_get(:@delegate)[:uid]).to eq(user.uid)
       expect_status.to eq(201)
 
       check_session


### PR DESCRIPTION
* Return '.to_i' value for integer types in 'Barong::App.config'
* Add 'hiredis' gem
* Refactor session opening
* Add additional 'IP' and 'Agent' fields in session
* Switch from cookie_store to cache_store
* Add additional AuthZ step 'validate_session!'
* Introduce additional 'IP' and 'Agent' validations
* Rework 'expire_time' logic
* Add renew 'expire_time' logic on every private request
* Add '/auth/sessions_spec' tests module