### PR TITLE
Session related improvements

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,20 +12,20 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
+  # Standard rails dev caching behaviour
+  # if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  #   config.action_controller.perform_caching = true
+  #   config.cache_store = :memory_store
+  #   config.public_file_server.headers = {
+  #     'Cache-Control' => "public, max-age=#{2.days.to_i}"
+  #   }
+  # else
+  #   config.action_controller.perform_caching = false
+  #   config.cache_store = :null_store
+  # end
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  # Using cache for sessions and permissions forces to use redis cache_store as mandatory store
+  config.cache_store = :redis_cache_store, { driver: :hiredis, url: Barong::App.config.redis_url }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
@@ -58,6 +58,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.cache_store = :redis_cache_store, { driver: :hiredis, url: Barong::App.config.redis_url }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,9 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # Using cache for sessions and permissions forces to use redis cache_store as mandatory store
+  config.cache_store = :redis_cache_store, { driver: :hiredis, url: Barong::App.config.redis_url }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "barong_#{Rails.env}"

--- a/config/initializers/barong.rb
+++ b/config/initializers/barong.rb
@@ -9,7 +9,6 @@ require 'barong/app'
 require 'barong/keystore'
 
 begin
-
   private_key_path = ENV['JWT_PRIVATE_KEY_PATH']
 
   if !private_key_path.nil?
@@ -27,11 +26,9 @@ begin
   else
     raise Barong::KeyStore::Fatal
   end
-
 rescue Barong::KeyStore::Fatal
   Rails.logger.fatal('Private key is invalid')
   raise 'FATAL: Private key is invalid'
-
 end
 
 kstore = Barong::KeyStore.new(pkey)
@@ -44,6 +41,8 @@ Barong::App.define do |config|
   config.set(:barong_maxminddb_path, '', type: :path)
   config.set(:session_expire_time, '1800', type: :integer)
   config.set(:barong_geoip_lang, 'en', values: %w[en de es fr ja ru])
+  config.set(:barong_session_name, '_barong_session')
+  config.set(:redis_url, 'redis://localhost:6379/1')
 end
 
 Barong::GeoIP.lang = Barong::App.config.barong_geoip_lang

--- a/config/initializers/redis_store.rb
+++ b/config/initializers/redis_store.rb
@@ -1,25 +1,27 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
-Barong::App.set(:redis_url, 'redis://localhost:6379/1')
-
-class Rack::Session::Redis
-  def set_session(env, session_id, new_session, options)
-    with_lock env, false do
-      with do |c|
-        new_options = if env['api_v2.session_lifetime']
-          x = ActionDispatch::Request::Session::Options.new \
-            options.instance_variable_get(:@by),
-            options.instance_variable_get(:@env),
-            options.instance_variable_get(:@delegate)
-          x[:expire_after] = env['api_v2.session_lifetime']
-          x
-        else
-          options
+module Rack
+  module Session
+    # redis store configuration class to act as session_store (cache_store)
+    class Redis
+      def set_session(env, session_id, new_session, options)
+        with_lock env, false do
+          with do |c|
+            new_options = if env['api_v2.session_lifetime']
+                            x = ActionDispatch::Request::Session::Options.new \
+                              options.instance_variable_get(:@by),
+                              options.instance_variable_get(:@env),
+                              options.instance_variable_get(:@delegate)
+                            x[:expire_after] = env['api_v2.session_lifetime']
+                            x
+                          else
+                            options
+                          end
+            c.set(session_id, new_session, new_options)
+          end
+          session_id
         end
-        c.set(session_id, new_session, new_options)
       end
-      session_id
     end
   end
 end

--- a/config/initializers/sessions_store.rb
+++ b/config/initializers/sessions_store.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal:true
+# frozen_string_literal: true
 
-# Store sessions in cache
-Rails.application.config.session_store :cache_store, key: '_barong_session', expire_after: 24.hours.seconds
+# Use cache_store as session_store for Rails sessions. Key default is '_barong_session'
+Rails.application.config.session_store :cache_store, key: Barong::App.config.barong_session_name, expire_after: 24.hours.seconds

--- a/lib/barong/authorize.rb
+++ b/lib/barong/authorize.rb
@@ -19,7 +19,6 @@ module Barong
     # init base request info, fetch black and white lists
     def initialize(request, path)
       @request = request
-      session[:init] = true
       @path = path
       @rules = lists['rules']
     end


### PR DESCRIPTION
* Comment out standard rails development cache configurations
* Force production and development envs to use redis_cache_store as
session_ and cache_ store
* Make session name to be configurable through BARONG_SESSION_NAME env
* Cosmetic improvments in sessions_store.rb due to code style rules
* Remove session[:init] in auth to avoid initing empty sessions (apikey)