### PR TITLE
Fix: add missing redis_url in Barong::App.config

### DIFF
--- a/config/initializers/barong.rb
+++ b/config/initializers/barong.rb
@@ -63,6 +63,7 @@ Barong::App.define do |config|
   config.set(:event_api_rabbitmq_password, 'guest')
   config.set(:vault_address, 'http://localhost:8200')
   config.set(:vault_token, 'changeme')
+  config.set(:redis_url, 'redis://localhost:6379/1')
 
   # CORS configuration  -----------------------------------------------
   config.set(:api_cors_origins, '*')


### PR DESCRIPTION
Already in the documentation with all descriptions, but was missing in the config