### PR TITLE
Enhancement: JWT expirating and Cache expiration policy improve

### DIFF
--- a/app/api/v2/exception_handlers.rb
+++ b/app/api/v2/exception_handlers.rb
@@ -24,7 +24,9 @@ module API
           end
 
           rescue_from(JWT::DecodeError) do |error|
-            error!({ errors: ['jwt.decode_and_verify'] }, 403)
+            # expired for "Signature has expired"   - expired token
+            # segments for "Not enough or too many segments"   - wrong token
+            error!({ errors: ["jwt.decode_and_verify.#{error.message.split.last}"] }, 422)
           end
 
           # Known Vault Error from TOTPService.with_human_error

--- a/app/api/v2/identity/users.rb
+++ b/app/api/v2/identity/users.rb
@@ -192,7 +192,7 @@ module API::V2
             reset_token = SecureRandom.hex(10)
             token = codec.encode(sub: 'reset', email: params[:email], uid: current_user.uid, reset_token: reset_token)
             # save reset_password_id in cache to validate as latest requested
-            Rails.cache.write("reset_password_#{params[:email]}", reset_token, expires_in: 3600.seconds)
+            Rails.cache.write("reset_password_#{params[:email]}", reset_token, expires_in: Barong::App.config.jwt_expire_time.seconds)
 
             activity_record(user: current_user.id, action: 'request password reset', result: 'succeed', topic: 'password')
 
@@ -256,7 +256,7 @@ module API::V2
             # remove latest token id cache record
             Rails.cache.delete("reset_password_#{params[:email]}")
             # invalidate token used
-            Rails.cache.write(payload[:jti], 'utilized')
+            Rails.cache.write(payload[:jti], 'utilized', expires_in: Barong::App.config.jwt_expire_time.seconds)
 
             activity_record(user: current_user.id, action: 'password reset', result: 'succeed', topic: 'password')
 

--- a/app/api/v2/identity/utils.rb
+++ b/app/api/v2/identity/utils.rb
@@ -91,7 +91,7 @@ module API::V2
 
       def token_uniq?(jti)
         error!({ errors: ['identity.user.utilized_token'] }, 422) if Rails.cache.read(jti) == 'utilized'
-        Rails.cache.write(jti, 'utilized')
+        Rails.cache.write(jti, 'utilized', expires_in: Barong::App.config.jwt_expire_time.seconds)
       end
 
       def publish_confirmation(user, domain)

--- a/config/initializers/barong.rb
+++ b/config/initializers/barong.rb
@@ -47,6 +47,7 @@ Barong::App.define do |config|
   config.set(:csrf_protection, 'true', type: :bool)
   config.set(:apikey_nonce_lifetime, '5000', type: :integer)
   config.set(:gateway, 'cloudflare', values: %w[akamai cloudflare])
+  config.set(:jwt_expire_time, '3600', type: :integer)
 
   # Password configuration  -----------------------------------------------
   # https://github.com/openware/barong/blob/master/docs/configuration.md#password-configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@
 | `barong_csrf_protection` | true | `true`, `false` | while turned on (`true`) exposes csrf_token on session create and requires X-CSRF-Token on every private POST PUT PATCH DELETE TRACE on AuthZ level |
 | `barong_apikey_nonce_lifetime` | 5000 | integer representation of milliseconds | nonce in api key headers should not be older than this env value  |
 | `barong_gateway` | 'cloudflare' | `cloudflare`, `akamai` | while turned on (`true`) user IP on session and AuthZ level will firstly be checked in TRUE_CLIENT_IP header |
+| `barong_jwt_expire_time` | '3600' | integer representation of seconds  | general purpose tokens (reset password, confirm email) expiration time |
 
 ### Password configuration
 | Env name | Default value | Possible values | Description |

--- a/lib/barong/authorize.rb
+++ b/lib/barong/authorize.rb
@@ -122,7 +122,7 @@ module Barong
 
     def validate_permissions!(user)
       # Caches Permission.all result to optimize
-      permissions = Rails.cache.fetch('permissions') { Permission.all.to_ary }
+      permissions = Rails.cache.fetch('permissions', expires_in: 5.minutes) { Permission.all.to_ary }
 
       permissions.select! { |a| a.role == user.role && ( a.verb == @request.env['REQUEST_METHOD'] || a.verb == 'ALL' ) && @path.starts_with?(a.path) }
       actions = permissions.blank? ? [] : permissions.pluck(:action).uniq

--- a/lib/barong/jwt.rb
+++ b/lib/barong/jwt.rb
@@ -5,7 +5,7 @@ module Barong
       raise "Missing private key" unless options[:key]
       @options = options.reverse_merge({
         algoritm: 'RS256',
-        expire: 3600,
+        expire: Barong::App.config.jwt_expire_time,
         sub: 'session',
         iss: 'barong',
         aud: %w[peatio barong]


### PR DESCRIPTION
* Change hardcoded 3600 seconds to BARONG_JWT_EXPIRE_TIME env
* Fix missing expires_in for utilized_tokens
* Add related specs
* Rework jwt.decode_and_verify to return uniq error on different validation