### PR TITLE
Enhancement: Use appropriate words

### DIFF
--- a/app/api/v2/identity/users.rb
+++ b/app/api/v2/identity/users.rb
@@ -17,7 +17,7 @@ module API::V2
 
       desc 'User related routes'
       resource :users do
-        desc 'Creates new whitelist restriction',
+        desc 'Creates new allowlist restriction',
         success: { code: 201, message: 'Creates new user' },
         failure: [
           { code: 400, message: 'Required params are missing' },
@@ -31,7 +31,7 @@ module API::V2
         post '/access' do
           if Rails.cache.read(params[:whitelink_token]) == 'active'
             restriction = Restriction.new(
-              category: 'whitelist',
+              category: 'allowlist',
               scope: 'ip',
               value: remote_ip,
               state: 'enabled'

--- a/app/models/data_storage.rb
+++ b/app/models/data_storage.rb
@@ -15,7 +15,7 @@
 
 # Data Storage model
 class DataStorage < ApplicationRecord
-  BLACKLISTED_TITLES = %w[document label profile phone user].freeze
+  DENYLISTED_TITLES = %w[document label profile phone user].freeze
   acts_as_eventable prefix: 'data_storage', on: %i[create update]
 
   belongs_to :user
@@ -24,7 +24,7 @@ class DataStorage < ApplicationRecord
   validates_length_of :data, maximum: 5120 # maximum 5kb of data
   validates :data, data_is_json: true
   validates :title, uniqueness: { scope: :user_id, case_sensitive: false },
-                    inclusion: { in: UserStorageTitles.list }, exclusion: { in: BLACKLISTED_TITLES }
+                    inclusion: { in: UserStorageTitles.list }, exclusion: { in: DENYLISTED_TITLES }
 
   def as_json_for_event_api
     {

--- a/app/models/restriction.rb
+++ b/app/models/restriction.rb
@@ -2,7 +2,7 @@
 
 class Restriction < ApplicationRecord
   # please, note that order in CATEGORIES contstant defines the ierarchy
-  CATEGORIES = %w[whitelist maintenance blacklist].freeze
+  CATEGORIES = %w[allowlist maintenance denylist].freeze
   SCOPES = %w[continent country ip ip_subnet all]
   # 423 Locked 403 Forbidden 401 Forbidden
   DEFAULT_CODES = { continent: 423, country: 423, ip_subnet: 403, ip: 401, all: 401 }.stringify_keys.freeze
@@ -27,7 +27,7 @@ class Restriction < ApplicationRecord
   private
 
   def assign_code
-    return unless code.blank? || category == 'whitelist'
+    return unless code.blank? || category == 'allowlist'
 
     self.code = category == 'maintenance' ? 471 : DEFAULT_CODES[scope]
   end

--- a/app/uploaders/upload_uploader.rb
+++ b/app/uploaders/upload_uploader.rb
@@ -16,8 +16,8 @@ class UploadUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_whitelist
-    Barong::App.config.upload_extension_whitelist
+  def extension_whitelist # TODO avoid using whitelist https://github.com/carrierwaveuploader/carrierwave/issues/2491
+    Barong::App.config.upload_extension_allowlist
   end
 
   def size_range

--- a/config/authz_rules.yml
+++ b/config/authz_rules.yml
@@ -1,6 +1,6 @@
 #
-# pass for whitelisted (public) routes
-# block for blacklisted routes
+# pass for allowlisted (public) routes
+# block for denylisted routes
 #
 rules:
   pass: 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -21,7 +21,7 @@ Barong::App.define do |config|
   config.set(:upload_size_min_range, '1', type: :integer) # in megabytes
   config.set(:upload_size_max_range, '10', type: :integer) # in megabytes
   config.set(:upload_auth_url_expiration, '1', type: :integer) # in minutes
-  config.set(:upload_extension_whitelist, 'jpg, jpeg, png, pdf', type: :array)
+  config.set(:upload_extension_allowlist, 'jpg, jpeg, png, pdf', type: :array)
 end
 
 CarrierWave.configure do |config|

--- a/config/initializers/user_storage_titles.rb
+++ b/config/initializers/user_storage_titles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# whitelisted data storage titles definitions
+# allowlisted data storage titles definitions
 class UserStorageTitles
   class << self
     def list

--- a/config/seeds.yml
+++ b/config/seeds.yml
@@ -21,12 +21,12 @@ levels:
     description: "User personal documents have been verified"
 
 restrictions:
-  - { category: whitelist, scope: country, value: UA, state: disabled }
+  - { category: allowlist, scope: country, value: UA, state: disabled }
   - { category: maintenance, scope: all, value: all, state: disabled }
-  - { category: blacklist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
-  - { category: blacklist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
-  - { category: blacklist, scope: country, value: USA, state: disabled, code: 435 }
-  - { category: blacklist, scope: continent, value: SA, state: disabled, code: 436 }
+  - { category: denylist, scope: ip, value: 164.116.47.255, state: disabled, code: 433 }
+  - { category: denylist, scope: ip_subnet, value: 164.116.47.0/24, state: disabled, code: 434 }
+  - { category: denylist, scope: country, value: USA, state: disabled, code: 435 }
+  - { category: denylist, scope: continent, value: SA, state: disabled, code: 436 }
 
 permissions:
 # SUPER ADMIN has an access to the whole system without any limits

--- a/db/migrate/20200625202452_replace_category_in_restrictions_table_with_appropriate_terms.rb
+++ b/db/migrate/20200625202452_replace_category_in_restrictions_table_with_appropriate_terms.rb
@@ -1,0 +1,11 @@
+class ReplaceCategoryInRestrictionsTableWithAppropriateTerms < ActiveRecord::Migration[5.2]
+  def change
+    queries = <<-SQL
+      UPDATE restrictions SET category = 'denylist' WHERE category = 'blacklist';
+      UPDATE restrictions SET category = 'allowlist' WHERE category = 'whitelist';
+    SQL
+    queries.split(';').each do |query| 
+      execute(query)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_104423) do
+ActiveRecord::Schema.define(version: 2020_06_25_202452) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ More details in [storage configuration doc](https://github.com/openware/barong/b
 | `barong_upload_size_min_range` | 1 | any integer value | minimum size of possible upload (in megabytes) |
 | `barong_upload_size_max_range` | 10 | any integer value | maximum size of possible upload (in megabytes) |
 | `barong_upload_auth_url_expiration` | 1 | any integer value | configures in minutes the lifetime of auth signature to see upload |
-| `barong_upload_extension_whitelist` | jpg, jpeg, png, pdf | string with comma-separated extensions formats | whitelist of upload extensions |
+| `barong_upload_extension_allowlist` | jpg, jpeg, png, pdf | string with comma-separated extensions formats | allowlist of upload extensions |
 
 ### API CORS configuration
 | Env name | Default value | Possible values | Description |
@@ -102,7 +102,7 @@ More details in [twilio configuration](https://github.com/openware/barong/blob/m
 | `barong_config`  | config/barong.yml | any valid path to existing file | path to barong config with `activation_requirements`, `state_triggers`, `document_types` and `user_storage_titles` |
 | `barong_maxminddb_path` | geolite/GeoLite2-Country.mmdb | any valid path to existing file | path to geolite country DB file |
 | `barong_seeds_file` | config/seeds.yml | any valid path to existing file | path to configuration file with pre-defined API rules, users and levels | 
-| `barong_authz_rules_file` | config/authz_rules.yml | any valid path to existing file | path to configuration file with blacklisted and whitelisted API pathes |
+| `barong_authz_rules_file` | config/authz_rules.yml | any valid path to existing file | path to configuration file with denylisted and allowlisted API pathes |
 
 # Barong configurations overview
 ## Twilio configuration
@@ -124,11 +124,11 @@ We have ability to set twilio with 3 different ways
 
 ---
 
-## Blacklist/Whitelist configuration
+## Denylist/Allowlist configuration
 
 `Pass` routes will never be checked by AuthZ endpoint and will be available without session requirement. On `Block` routes user always will get 401, it doesn't depend on a session / role / ip / etc
 
-You need to put whitelisted (public) routes for pass object and blacklisted routes for block in authz_rules.yml
+You need to put allowlisted (public) routes for pass object and denylisted routes for block in authz_rules.yml
 
 ```yml
 rules:

--- a/docs/general/errors.md
+++ b/docs/general/errors.md
@@ -69,7 +69,7 @@ authz.invalid_signature         API Key header 'signature' is invalid
 authz.apikey_not_active         API Key state is 'inactive'
 authz.disabled_2fa              API Key owner has disabled 2FA
 authz.invalid_api_key_headers   Blank or missing API Key headers
-authz.permission_denied         Path is blacklisted
+authz.permission_denied         Path is denylisted
 authz.unexistent_apikey         X-Auth-Apikey header is invalid
 ```
 

--- a/docs/restrictions.md
+++ b/docs/restrictions.md
@@ -1,49 +1,49 @@
 # Restrictions
 
 ### Introduction
-First version of restrictions appeared in 2.3 as simple blacklist feature, by IP in several scopes (by `country`, by `continent`, by `ip_subnet` and by `ip`).
+First version of restrictions appeared in 2.3 as simple denylist feature, by IP in several scopes (by `country`, by `continent`, by `ip_subnet` and by `ip`).
 
 Starting from latest 2.4 restrictions will act as system of traffic control. New fields added to restrictions table - `category`, `code`, and new available value for `scope` - `all`
 
 ##### Main points: 
 Every request to the server will be validated (both `public` and `private` APIs, but not `management` one ). Request IP will match with existing restrictions and a first found rule will be applayed. 
-`category` - one of `whitelist`, `maintenance`, `blacklist`. 
+`category` - one of `allowlist`, `maintenance`, `denylist`. 
 
 The order of matching IP with existing rules is strict and cant be changed: 
-1. Whitelist ( all -> ip -> ip_subnet -> country -> continent )
+1. Allowlist ( all -> ip -> ip_subnet -> country -> continent )
 2. Maintenance ( all -> ip -> ip_subnet -> country -> continent )
-3. Blacklist ( all -> ip -> ip_subnet -> country -> continent )
+3. Denylist ( all -> ip -> ip_subnet -> country -> continent )
 
-`Whitelist` - rule, that marks IP as trusted, as IP that can have an access to the server APIs
+`Allowlist` - rule, that marks IP as trusted, as IP that can have an access to the server APIs
 `Maintenance` - when enabled, will return an error - 471 (by default) to any request to server in a range of rules `scope` (Typically, should be used with `all` and in maintenance platform purposes)
-`Blacklist` - when enabled, will return an error - `code`, which can be customized by the rule. Code can be different for different `scopes`, and can be used to display different error or kind alert of UI. Default `code` for errors `{ continent: 423, country: 423, ip_subnet: 403, ip: 401, all: 401 }`
+`Denylist` - when enabled, will return an error - `code`, which can be customized by the rule. Code can be different for different `scopes`, and can be used to display different error or kind alert of UI. Default `code` for errors `{ continent: 423, country: 423, ip_subnet: 403, ip: 401, all: 401 }`
 
 ##### How to configure
 Restrictions can be:
 1. Seeded via seed feature. 
-Just put restrictions in format of   `- { category: whitelist, scope: country, value: UA, state: disabled }` in seed.yml under `restrictions:` module
+Just put restrictions in format of   `- { category: allowlist, scope: country, value: UA, state: disabled }` in seed.yml under `restrictions:` module
 2. Can be added by admin via `api/v2/barong/admin/restrictions`, 
     requires `:scope`, requires `:value`, requires `:category`, optional `:state, default: 'enabled`', optional `:code `
-3. Can be added automatically (whitelist category) via whitelink feature
+3. Can be added automatically (allowlist category) via whitelink feature
 
 ### Whitelink feature
-In order to make the process of whitelisting IPs easier starting from latest 2.4 admin can create a `whitelink_token` via
-`api/v2/barong/admin/restrictions/whitelink`. Created token can be sent to `api/v2/barong/identity/users/access` and if it is valid (every token has expiry time, which is 1 day by default) and it will automatically create a `whitelist` restriction with current request IP.
-Note: `api/v2/barong/identity/users/access` API available to call even if all other platform traffic is under blacklist or maintenance
+In order to make the process of allowlisting IPs easier starting from latest 2.4 admin can create a `whitelink_token` via
+`api/v2/barong/admin/restrictions/whitelink`. Created token can be sent to `api/v2/barong/identity/users/access` and if it is valid (every token has expiry time, which is 1 day by default) and it will automatically create a `allowlist` restriction with current request IP.
+Note: `api/v2/barong/identity/users/access` API available to call even if all other platform traffic is under denylist or maintenance
 
 ### Restrictions Usage
-Combining whitelist, maintenance and blacklist rules can help in controlling platform traffic, maintaining platform, developing custom cases and complex UI structure.
+Combining allowlist, maintenance and denylist rules can help in controlling platform traffic, maintaining platform, developing custom cases and complex UI structure.
 ##### Several usecases:
 ##### Maintenance - rules:
 `category: 'maintenance', scope: 'all', value: 'all', state: 'enabled', code: 471`
-`category: 'whitelist', scope: 'ip_subnet', value: '#{dev_team_office_ip}', state: 'enabled'`
+`category: 'allowlist', scope: 'ip_subnet', value: '#{dev_team_office_ip}', state: 'enabled'`
 
-In this case all users, that will try to access any API of the platform will get a responce with status `471` and body `authz.restrict.maintenance`. In this case frontend can show a maintenance page for users, so they will understand that platform is under service right now. Meanwhile, all requests from `#{dev_team_office_ip}` (as they are whitelisted) will still reach server and can test the update / validate any bug found, etc.
+In this case all users, that will try to access any API of the platform will get a responce with status `471` and body `authz.restrict.maintenance`. In this case frontend can show a maintenance page for users, so they will understand that platform is under service right now. Meanwhile, all requests from `#{dev_team_office_ip}` (as they are allowlisted) will still reach server and can test the update / validate any bug found, etc.
 
-##### Blacklisting - rules:
-`category: 'blacklist', scope: 'country', value: 'US', state: 'enabled', code: 455`
-`category: 'blacklist', scope: 'continent', value: 'NA', state: 'enabled', code: 456`
-`category: 'whitelist', scope: 'ip', value: '#{investor_ip}', state: 'enabled'`
+##### Denylisting - rules:
+`category: 'denylist', scope: 'country', value: 'US', state: 'enabled', code: 455`
+`category: 'denylist', scope: 'continent', value: 'NA', state: 'enabled', code: 456`
+`category: 'allowlist', scope: 'ip', value: '#{investor_ip}', state: 'enabled'`
 
-In this case all users from North America, that will try to access any API of the platform will get a responce with status `456` and body `authz.restrict.blacklist`. In this case frontend can show a page for users, so they will understand that they cant yet reach this platform from their current location, but it will come soon. All users from USA will have a different code - `455`, so UI can show the page, which will indicates, that platform is banned for USA residents and cant be reached from this country.
-Meanwhile, in testing and business purpose you can whitelist one concrete or subset of IPs, for you investors, for lawyers or any demo, using `whitelist` rule.
+In this case all users from North America, that will try to access any API of the platform will get a responce with status `456` and body `authz.restrict.denylist`. In this case frontend can show a page for users, so they will understand that they cant yet reach this platform from their current location, but it will come soon. All users from USA will have a different code - `455`, so UI can show the page, which will indicates, that platform is banned for USA residents and cant be reached from this country.
+Meanwhile, in testing and business purpose you can allowlist one concrete or subset of IPs, for you investors, for lawyers or any demo, using `allowlist` rule.

--- a/spec/api/v2/admin/restrictions_spec.rb
+++ b/spec/api/v2/admin/restrictions_spec.rb
@@ -8,9 +8,9 @@ describe API::V2::Admin::Restrictions do
 
   describe 'GET /api/v2/admin/restrictions' do
     before do
-      create(:restriction, scope: 'ip', value: '0.0.0.1', category: 'blacklist', updated_at: 1.days.ago)
-      create(:restriction, scope: 'ip', value: '0.0.0.0', category: 'blacklist', updated_at: 3.days.ago)
-      create(:restriction, scope: 'ip_subnet', value: '1.2.3.4/24', category: 'blacklist', updated_at: 3.days.ago)
+      create(:restriction, scope: 'ip', value: '0.0.0.1', category: 'denylist', updated_at: 1.days.ago)
+      create(:restriction, scope: 'ip', value: '0.0.0.0', category: 'denylist', updated_at: 3.days.ago)
+      create(:restriction, scope: 'ip_subnet', value: '1.2.3.4/24', category: 'denylist', updated_at: 3.days.ago)
     end
 
     context 'successful response' do
@@ -29,10 +29,10 @@ describe API::V2::Admin::Restrictions do
       end
 
       it 'filters by category' do
-        get '/api/v2/admin/restrictions', headers: auth_header, params: { category: 'blacklist' }
+        get '/api/v2/admin/restrictions', headers: auth_header, params: { category: 'denylist' }
 
-        expect(json_body.length).to eq Restriction.where(category: 'blacklist').count
-        expect(json_body.map { |r| r[:category] }).to all eq 'blacklist'
+        expect(json_body.length).to eq Restriction.where(category: 'denylist').count
+        expect(json_body.map { |r| r[:category] }).to all eq 'denylist'
       end
 
       it 'filters with date range' do
@@ -84,7 +84,7 @@ describe API::V2::Admin::Restrictions do
   describe 'POST /api/v2/admin/restrictions' do
     it 'creates new restriction' do
       expect {
-        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'blacklist' }
+        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'denylist' }
       }.to change { Restriction.count }.by(1)
 
       expect(response).to be_successful
@@ -92,15 +92,15 @@ describe API::V2::Admin::Restrictions do
 
     it 'creates new restriction with code' do
       expect {
-        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'blacklist', code: 522 }
+        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'denylist', code: 522 }
       }.to change { Restriction.count }.by(1)
 
       expect(response).to be_successful
     end
 
-    it 'creates new whitelist restriction' do
+    it 'creates new allowlist restriction' do
       expect {
-        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'whitelist' }
+        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.0.0.0', category: 'allowlist' }
       }.to change { Restriction.count }.by(1)
 
       expect(response).to be_successful
@@ -123,7 +123,7 @@ describe API::V2::Admin::Restrictions do
       end
 
       it 'value' do
-        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.a.b.c', category: 'blacklist' }
+        post '/api/v2/admin/restrictions', headers: auth_header, params: { scope: 'ip', value: '127.a.b.c', category: 'denylist' }
 
         expect(json_body[:errors]).to include "value.invalid"
       end
@@ -137,7 +137,7 @@ describe API::V2::Admin::Restrictions do
   end
 
   describe 'PUT /api/v2/admin/restrictions' do
-    let!(:restriction) { create(:restriction, scope: 'ip', value: '127.0.0.1', category: 'blacklist') }
+    let!(:restriction) { create(:restriction, scope: 'ip', value: '127.0.0.1', category: 'denylist') }
 
     it 'updates state' do
       expect {
@@ -171,13 +171,13 @@ describe API::V2::Admin::Restrictions do
 
     it 'updates category' do
       expect {
-        put '/api/v2/admin/restrictions', headers: auth_header, params: { id: restriction.id, category: 'whitelist' }
-      }.to change { restriction.reload.category }.to('whitelist')
+        put '/api/v2/admin/restrictions', headers: auth_header, params: { id: restriction.id, category: 'allowlist' }
+      }.to change { restriction.reload.category }.to('allowlist')
     end
   end
 
   describe 'DELETE /api/v2/admin/restrictions' do
-    let!(:restriction) { create(:restriction, scope: 'ip', value: '127.0.0.1', category: 'blacklist') }
+    let!(:restriction) { create(:restriction, scope: 'ip', value: '127.0.0.1', category: 'denylist') }
 
     context 'successful response' do
       let(:do_request) { delete '/api/v2/admin/restrictions', params: { id: restriction.id }, headers: auth_header }

--- a/spec/api/v2/auth/auth_spec.rb
+++ b/spec/api/v2/auth/auth_spec.rb
@@ -157,16 +157,16 @@ describe '/api/v2/auth functionality test' do
 
       let(:do_restricted_request) { put '/api/v2/auth/api/v2/peatio/management/ping' }
 
-      it 'receives access error if path is blacklisted' do
+      it 'receives access error if path is denylisted' do
         do_restricted_request
         expect(response.status).to eq(401)
         expect(response.body).to eq("{\"errors\":[\"authz.permission_denied\"]}")
       end
 
-      let(:do_whitelisted_request) { put '/api/v2/auth/api/v2/peatio/public/ping' }
+      let(:do_allowlisted_request) { put '/api/v2/auth/api/v2/peatio/public/ping' }
 
-      it 'receives access error if path is blacklisted' do
-        do_whitelisted_request
+      it 'receives access error if path is denylisted' do
+        do_allowlisted_request
         expect(response.status).to eq(200)
         expect(response.body).to be_empty
         expect(response.headers['Authorization']).to be_nil
@@ -341,13 +341,13 @@ describe '/api/v2/auth functionality test' do
         }
       }
 
-      it 'receives access error if path is blacklisted' do
+      it 'receives access error if path is denylisted' do
         do_restricted_request
         expect(response.status).to eq(401)
         expect(response.body).to eq("{\"errors\":[\"authz.permission_denied\"]}")
       end
 
-      let(:do_whitelisted_request) {
+      let(:do_allowlisted_request) {
         put '/api/v2/auth/api/v2/peatio/public/ping', headers: {
           'X-Auth-Apikey' => kid,
           'X-Auth-Nonce' => nonce,
@@ -355,8 +355,8 @@ describe '/api/v2/auth functionality test' do
         }
       }
 
-      it 'receives access error if path is whitelisted' do
-        do_whitelisted_request
+      it 'receives access error if path is allowlisted' do
+        do_allowlisted_request
         expect(response.status).to eq(200)
         expect(response.body).to be_empty
         expect(response.headers['Authorization']).to be_nil

--- a/spec/api/v2/resource/data_storage_spec.rb
+++ b/spec/api/v2/resource/data_storage_spec.rb
@@ -32,8 +32,8 @@ describe 'Api::V2::Resource::DataStorage' do
 
     context 'errors' do
       let(:non_json_data_params) { { title: 'personal', data: 'My name is John Doe. Hello, World!' } }
-      let(:non_whitelisted_params) { { title: 'family_info', data: { wife_first_name: Faker::Name.first_name }.to_json } }
-      let(:blacklisted_params) { { title: 'document', data: { approved: true }.to_json } }
+      let(:non_allowlisted_params) { { title: 'family_info', data: { wife_first_name: Faker::Name.first_name }.to_json } }
+      let(:denylisted_params) { { title: 'document', data: { approved: true }.to_json } }
 
       it 'doesnt accept non-json data' do
         expect { post url, params: non_json_data_params, headers: auth_header }.not_to change { DataStorage.count }
@@ -42,14 +42,14 @@ describe 'Api::V2::Resource::DataStorage' do
         expect(json_body).to eq({errors: ['data.invalid_format']})
       end
 
-      it 'doesnt accept non-whitelisted title' do
-        expect { post url, params: non_whitelisted_params, headers: auth_header }.not_to change { DataStorage.count }
+      it 'doesnt accept non-allowlisted title' do
+        expect { post url, params: non_allowlisted_params, headers: auth_header }.not_to change { DataStorage.count }
         expect(response.status).to eq(422)
         expect(json_body).to eq({errors: ['title.inclusion']})
       end
 
-      it 'doesnt accept blacklisted title' do
-        expect { post url, params: blacklisted_params, headers: auth_header }.not_to change { DataStorage.count }
+      it 'doesnt accept denylisted title' do
+        expect { post url, params: denylisted_params, headers: auth_header }.not_to change { DataStorage.count }
         expect(response.status).to eq(422)
         expect(json_body).to eq({errors: ['title.inclusion', 'title.exclusion']})
       end

--- a/spec/lib/barong/seed_spec.rb
+++ b/spec/lib/barong/seed_spec.rb
@@ -362,7 +362,7 @@ describe Barong::Seed do
           "state" => "enabled"
         },
         {
-          "category" => "blacklist",
+          "category" => "denylist",
           "scope" => "all",
           "value" => "all",
           "state" => "enabled"

--- a/spec/models/restrictions_spec.rb
+++ b/spec/models/restrictions_spec.rb
@@ -7,27 +7,27 @@ RSpec.describe Restriction, type: :model do
     it { should_not allow_value('planet').for(:scope) }
 
     it 'valid address with ip scope' do
-      expect(Restriction.new(scope: 'ip', value: '127.0.0.1', category: 'blacklist').valid?).to be_truthy
+      expect(Restriction.new(scope: 'ip', value: '127.0.0.1', category: 'denylist').valid?).to be_truthy
     end
 
     it 'invalid address with ip scope' do
-      expect(Restriction.new(scope: 'ip', value: 'abc.0.0.1', category: 'blacklist').valid?).to be_falsey
+      expect(Restriction.new(scope: 'ip', value: 'abc.0.0.1', category: 'denylist').valid?).to be_falsey
     end
 
     it 'ip subnet with ip scope' do
-      expect(Restriction.new(scope: 'ip', value: '127.0.0.1/24', category: 'blacklist').valid?).to be_falsey
+      expect(Restriction.new(scope: 'ip', value: '127.0.0.1/24', category: 'denylist').valid?).to be_falsey
     end
 
     it 'valid subnet with ip_subnet scope' do
-      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1/24', category: 'blacklist').valid?).to be_truthy
+      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1/24', category: 'denylist').valid?).to be_truthy
     end
 
     it 'invalid subnet with ip_subnet scope' do
-      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1/one', category: 'blacklist').valid?).to be_falsey
+      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1/one', category: 'denylist').valid?).to be_falsey
     end
 
     it 'ip address with ip_subnet scope' do
-      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1', category: 'blacklist').valid?).to be_falsey
+      expect(Restriction.new(scope: 'ip_subnet', value: '127.0.0.1', category: 'denylist').valid?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
The technology industry has started to replace problematic racist terminology with more appropriate and precise. It's time to shift from naming conventions, which cause misunderstanding.

### [Google](https://developers.google.com/style/word-list)
> Avoid blacklist and whitelist. Instead, use more precise terms that are appropriate to your domain, such as denylist/allowlist or blocklist/allowlist.
### [IBM](https://cloud.ibm.com/docs/overview?topic=overview-glossary)
> allowlist
> A list of items, such as usernames, email addresses, or IP addresses, that are granted access to a certain system or function. When an allowlist is used for access control, all entities are denied access, except for those that are included in the allowlist. See also blocklist.
> blocklist
> A list of items, such as usernames, email addresses, or IP addresses, that are denied access to a certain system or function. When a blocklist is used for access control, all entities are allowed access, except for those that are included in the blocklist. See also allowlist.