### PR TITLE
Handle OpenURI::HTTPError 404 && avoid OpenURI StringIO creation

### DIFF
--- a/app/workers/kyc/kycaid/address_worker.rb
+++ b/app/workers/kyc/kycaid/address_worker.rb
@@ -27,6 +27,9 @@ module KYC
 
           Rails.logger.info("Verification for user address with uid: #{@user.uid}, kycaid id of verification: #{verification.verification_id}")
         end
+      rescue OpenURI::HTTPError => e
+        Rails.logger.info("#{self.class} caught #{e.inspect()}, retrying in 30 seconds")
+        self.class.perform_in(30.seconds, params)
       end
 
       def address_params

--- a/app/workers/kyc/kycaid/document_worker.rb
+++ b/app/workers/kyc/kycaid/document_worker.rb
@@ -39,6 +39,9 @@ module KYC
 
           Rails.logger.info("Verification for user document with uid: #{@user.uid}, kycaid id of verification: #{verification.verification_id}")
         end
+      rescue OpenURI::HTTPError => e
+        Rails.logger.info("#{self.class} caught #{e.inspect()}, retrying in 30 seconds")
+        self.class.perform_in(30.seconds, user_id, identificator)
       end
 
       def document_params(front_file, back_file)

--- a/config/initializers/open_uri.rb
+++ b/config/initializers/open_uri.rb
@@ -1,0 +1,4 @@
+# Don't allow downloaded files to be created as StringIO. Create a tempfile instead
+
+OpenURI::Buffer.send :remove_const, 'StringMax' if OpenURI::Buffer.const_defined?('StringMax')
+OpenURI::Buffer.const_set 'StringMax', 0


### PR DESCRIPTION
* decrease OpenURI::Buffer::StringMax to 0 to force Temfile creation
* rescue OpenURI::HTTPError in KYCAID workers