### PR TITLE
Feature: Add Document to abilities

### DIFF
--- a/config/abilities.yml
+++ b/config/abilities.yml
@@ -18,6 +18,7 @@ admin_permissions:
       - APIKey
       - Permission
       - Restriction
+      - Document
   admin:
     read:
       - Activity
@@ -30,6 +31,7 @@ admin_permissions:
       - Profile
       - APIKey
       - Restriction
+      - Document
   technical:
     read:
       - Ability
@@ -53,6 +55,7 @@ admin_permissions:
     read:
       - Ability
       - Activity
+      - Document
     manage:
       - User
       - Level


### PR DESCRIPTION
Tower restricts the ability to open documents attachments for users, who don't have the `read Document` ability