### PR TITLE
Feature: Add IP country for admin user activities api (Rebased on master)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/app/api/v2/admin/entities/activity_with_user.rb
+++ b/app/api/v2/admin/entities/activity_with_user.rb
@@ -9,6 +9,13 @@ module API::V2::Admin
               desc: 'User IP'
              }
 
+      expose :user_ip_country,
+             documentation: {
+               type: 'String'
+             } do |activity|
+               Barong::GeoIP.info(ip: activity.user_ip, key: :country)
+             end
+
       expose :user_agent,
              documentation: {
               type: 'String',

--- a/app/api/v2/admin/entities/admin_activity.rb
+++ b/app/api/v2/admin/entities/admin_activity.rb
@@ -9,6 +9,13 @@ module API::V2::Admin
               desc: 'User IP'
              }
 
+      expose :user_ip_country,
+             documentation: {
+               type: 'String'
+             } do |activity|
+               Barong::GeoIP.info(ip: activity.user_ip, key: :country)
+             end
+
       expose :user_agent,
              documentation: {
               type: 'String',

--- a/spec/api/v2/admin/activities_spec.rb
+++ b/spec/api/v2/admin/activities_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe API::V2::Admin::Activities do
   include_context 'bearer authentication'
+  include_context 'geoip mock'
 
   describe 'GET /api/v2/admin/activities' do
     let!(:create_admin_permission) do
@@ -42,6 +43,7 @@ describe API::V2::Admin::Activities do
           user_activites = Activity.where(category: 'user')
           expect(user_activites.count).to eq activities.count
           expect(user_activites.last.user_ip).to eq activities[0]['user_ip']
+          expect(Barong::GeoIP.info(ip: user_activites.last.user_ip, key: :country)).to eq activities[0]['user_ip_country']
           expect(user_activites.last.user_agent).to eq activities[0]['user_agent']
           expect(user_activites.last.topic).to eq activities[0]['topic']
           expect(user_activites.last.action).to eq activities[0]['action']
@@ -94,6 +96,7 @@ describe API::V2::Admin::Activities do
 
           expect(Activity.count).to eq activities.count
           expect(Activity.third.user_ip).to eq activities[0]['user_ip']
+          expect(Barong::GeoIP.info(ip: Activity.third.user_ip, key: :country)).to eq activities[0]['user_ip_country']
           expect(Activity.third.user_agent).to eq activities[0]['user_agent']
           expect(Activity.third.topic).to eq activities[0]['topic']
           expect(Activity.third.action).to eq activities[0]['action']


### PR DESCRIPTION
Add IP country for admin user activities API.
This feature related to display IP country on the user activities page in Tower.

Original PR: https://github.com/openware/barong/pull/1217